### PR TITLE
Updated @cesium/wasm-splats version number

### DIFF
--- a/wasm-splats/Cargo.toml
+++ b/wasm-splats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-splats"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = ["Cesium GS, Inc. <https://cesium.com>"]
 edition = "2021"
 homepage = "https://cesium.com/cesiumjs/"


### PR DESCRIPTION
Updated `@cesium/wasm-splats` version number to `0.1.0-alpha.2` prior to publish.